### PR TITLE
support Android9 & Android10

### DIFF
--- a/app/src/main/java/ksnd/deviceauthenticationsample/biometric/AppBiometricManager.kt
+++ b/app/src/main/java/ksnd/deviceauthenticationsample/biometric/AppBiometricManager.kt
@@ -1,7 +1,9 @@
 package ksnd.deviceauthenticationsample.biometric
 
+import android.os.Build
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
 import androidx.biometric.BiometricPrompt
 import androidx.fragment.app.FragmentActivity
@@ -16,6 +18,15 @@ import javax.inject.Inject
 class AppBiometricManager @Inject constructor(
     private val biometricManager: BiometricManager,
 ) {
+    /**
+     * 利用可能な認証方法
+     */
+    private val authenticators = if (Build.VERSION.SDK_INT > Build.VERSION_CODES.R) {
+        BIOMETRIC_STRONG or DEVICE_CREDENTIAL
+    } else {
+        BIOMETRIC_WEAK or DEVICE_CREDENTIAL
+    }
+
     /**
      * デバイス認証を行う
      *
@@ -38,7 +49,7 @@ class AppBiometricManager @Inject constructor(
      * デバイス認証が利用可能かチェックする
      */
     private fun checkAvailableAuthenticate() {
-        val result = biometricManager.canAuthenticate(BIOMETRIC_STRONG or DEVICE_CREDENTIAL)
+        val result = biometricManager.canAuthenticate(authenticators)
         if (result == BiometricManager.BIOMETRIC_SUCCESS) return
 
         when (result) {
@@ -84,7 +95,7 @@ class AppBiometricManager @Inject constructor(
 
         val promptInfo = BiometricPrompt.PromptInfo.Builder()
             .setTitle("デバイス認証")
-            .setAllowedAuthenticators(BIOMETRIC_STRONG or DEVICE_CREDENTIAL)
+            .setAllowedAuthenticators(authenticators)
             .build()
 
         biometricPrompt.authenticate(promptInfo)


### PR DESCRIPTION
## issue
- fix: #4 

## ref
https://developer.android.com/training/sign-in/biometric-auth#:~:text=KeyguardManager.isDeviceSecure()%20%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%BE%E3%81%99

## memo
- ドキュメントにはAndroid10以下では`KeyguardManager.isDeviceSecure()`使えって書いてあるが、エミュレータでAndroid10とAndroid9の両方でパスワード登録されていればパスワード入力できて、パスワード登録されていなければ、登録されていないとエラーコードちゃんと返ってきていた...???